### PR TITLE
Adds debian buster workstation template

### DIFF
--- a/workstation/dom0/f25/qubes-template-securedrop-workstation-buster-4.0.1-201911061435.noarch.rpm
+++ b/workstation/dom0/f25/qubes-template-securedrop-workstation-buster-4.0.1-201911061435.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95ed188e542f2e8a0aab4e4eda3e7e7944c502398167f636d9c4fe843f359590
+size 852837472


### PR DESCRIPTION
### Test plan
- [x] verify this rpm is correctly signed: `rpm -Kv <file.rpm>`
- [x] Template installs successfully in dom0
- `qvm-prefs securedrop-workstation-buster kernel ''`
- 'qvm-prefs securedrop-wokrstation-buster virt_mode hvm`
- [x] Template boots and is running grsecurity kernel
- [ ] Build logs are found in https://github.com/freedomofpress/build-logs/