### PR TITLE
Remove historical Qubes templates

### DIFF
--- a/workstation/dom0/f25/qubes-template-securedrop-workstation-4.0.1-201810051550.noarch.rpm
+++ b/workstation/dom0/f25/qubes-template-securedrop-workstation-4.0.1-201810051550.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cd1e89ac80f9c0b9b5dc296f1f5fdfa42c6e21d8ff92b613e57cfb46643a70e4
-size 743733840

--- a/workstation/dom0/f25/qubes-template-securedrop-workstation-4.0.1-201904121810.noarch.rpm
+++ b/workstation/dom0/f25/qubes-template-securedrop-workstation-4.0.1-201904121810.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e35c434faf5e485e52c93b10315b82208d22aa02d877ace2f4707839b8fe9506
-size 748557372

--- a/workstation/dom0/f25/qubes-template-securedrop-workstation-4.0.1-201905012028.noarch.rpm
+++ b/workstation/dom0/f25/qubes-template-securedrop-workstation-4.0.1-201905012028.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9a58694db23b838409b0261d88039f6bbfadd78bf9861869edda4454d21e4855
-size 752769804

--- a/workstation/dom0/f25/qubes-template-securedrop-workstation-4.0.1-201905141842.noarch.rpm
+++ b/workstation/dom0/f25/qubes-template-securedrop-workstation-4.0.1-201905141842.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:abe1758d77d404a3a2ba91f2055f40e9c9967541e341375686086c55603f1a9d
-size 751771168

--- a/workstation/dom0/f25/qubes-template-securedrop-workstation-4.0.1-201906251955.noarch.rpm
+++ b/workstation/dom0/f25/qubes-template-securedrop-workstation-4.0.1-201906251955.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7d19b0703fa27f6fd14738ac2415b19e813a1f03b9461648b71a7a277d9cd932
-size 756282200


### PR DESCRIPTION
All these  will save 4GB of bandwith every time this repository is cloned. These are Stretch-based templates which and end-of life and have only been used in development context.

Note that CI is failing, but CI is not yet set up on master. 

We should never need these specific artifacts, but for posterity (as we may want to keep any production artifact we ship), does anyone know what is the "retention policy" for LFS is? Should we push to a separate branch to ensure the files are still stored (but not accessed all the time)?