### PR TITLE
Adds 0.1.2 dom0-config package with split dev/prod logic

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.1.2-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.1.2-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:520db1b7d4270fc5f51971c9ff0c52e42ce3c84e4842bc73408b9dc7155ae3ad
+size 105582


### PR DESCRIPTION
Package built on securedrop-workstation branch `406-prod-make-targets` and signed with the test key.

This will be required to fully test the split logic in https://github.com/freedomofpress/securedrop-workstation/pull/432

Since the yum.freedom.press server is not yet online, the test may not be completely conclusive

