### PR TITLE
Provide qubes-template-securedrop-workstation for beta release

### DIFF
--- a/workstation/dom0/f25/qubes-template-securedrop-workstation-buster-4.0.1-202002142107.noarch.rpm
+++ b/workstation/dom0/f25/qubes-template-securedrop-workstation-buster-4.0.1-202002142107.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb696536b097a52d096f3f96fb09cb0a9c90da002e61e2c11ab8884f6c8f438d
+size 864108052

--- a/workstation/dom0/f25/qubes-template-securedrop-workstation-buster-4.0.1-202002142107.noarch.rpm
+++ b/workstation/dom0/f25/qubes-template-securedrop-workstation-buster-4.0.1-202002142107.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fb696536b097a52d096f3f96fb09cb0a9c90da002e61e2c11ab8884f6c8f438d
+oid sha256:883a55123fcc879ba494db6ff483522fb7e8f2d07099c2d1d5b3619c2effca83
 size 864108052


### PR DESCRIPTION
Towards https://github.com/freedomofpress/securedrop-workstation/issues/424

Built using prod-apt server and prod tag https://github.com/freedomofpress/qubes-template-securedrop-workstation/releases/tag/v0.2b
- build logs: https://github.com/freedomofpress/build-logs/commit/cfe5e23890ff85a9169ce29c9b08333b87e6f2a6
- 2599022 contains the _unsigned_ rpm, which will be used to verify the prod release: `rpm --delsign` of the current artifact should have the same hash as artifact in 2599022.

Test plan (I performed this test plan locally):
- `make clean` and remove qubes-template-securedrop-workstation
- copy rpm to dom0
- `sudo rpm -i <template>`
- `make all`