### PR TITLE
Removes 0.3.0~rc1 dom0 config rpm package

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.0~rc1-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.0~rc1-1.fc25.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:554189096a9dbd1489876b99f540750bf4e62e64fa831dfd4270087d39019943
-size 107530


### PR DESCRIPTION
The tilde in the version string doesn't play nicely with the regex
validation logic in `qubes-receive-updates`; see discussion in [0].
Removing the package for now, we'll follow up with a subsequent package
that works with the tooling.

[0] https://github.com/freedomofpress/securedrop-workstation/issues/540#issuecomment-628157150