### PR TITLE
SecureDrop Workstation 0.3.0 rc1 rpm package

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.0-0.rc1.1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.0-0.rc1.1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55ea460d46cd9d1ac8f0bb0f2f03ac5a6dda69e679f6696c071b1c3074c09b49
+size 107566

--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.0-0.rc1.1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.0-0.rc1.1.fc25.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:55ea460d46cd9d1ac8f0bb0f2f03ac5a6dda69e679f6696c071b1c3074c09b49
+oid sha256:6f80f017e10bcc0cf21412a38a072b6b68ec45f1ce708f119688eb8ae9816ac6
 size 107566


### PR DESCRIPTION
Closes https://github.com/freedomofpress/securedrop-workstation/issues/540

Build logs https://github.com/freedomofpress/build-logs/commit/9c2d0bc2cf8f495cb51a6a2bd07c3c9491c4b283

Test plan
- [ ] 0.3.0-rc1 tag in `securedrop-workstation` repository is correct 
- [ ] Build logs are included
- [ ] CI is passing, the rpm is properly signed with the test key
- [ ] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs