### PR TITLE
SecureDrop Workstation 0.3.0-rc2 RPM packages

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.0-0.rc2.1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.0-0.rc2.1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66cdd1c6ad8cbb0fbd848b684d0974311912288c136db5510634e176e6b38d73
+size 107782

--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.0-0.rc2.1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.0-0.rc2.1.fc25.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:66cdd1c6ad8cbb0fbd848b684d0974311912288c136db5510634e176e6b38d73
+oid sha256:590f155355b5b9a7a4db7b17802dabbbf677e3cc7033a35799aaa0545ff491af
 size 107782


### PR DESCRIPTION
Build logs: https://github.com/freedomofpress/build-logs/commit/edfeb5d7d92d883e4990ea80382191adb64e896b


Test plan
- [ ] 0.3.0-rc2 tag in `securedrop-workstation` repository is correct 
- [ ] Build logs are included
- [ ] CI is passing, the rpm is properly signed with the test key
- [ ] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs