### PR TITLE
Adds PR template for dev LFS packages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+###
+Name of package:
+
+
+### Test plan
+
+- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/x.y.z
+- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/1234
+- [ ] CI is passing, the rpm is properly signed with the test key
+- [ ] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs


### PR DESCRIPTION
Based on GitHub docs [0]. Includes the standard testing steps
for a reviewer to confirm package integrity prior to building.

[0] https://help.github.com/en/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository

Cf. https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/pull/11 