### PR TITLE
SecureDrop Workstation RPM 0.3.1-rc1

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.0-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.0-1.fc25.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0c0e0a425f49bd4b5a457d6cc4f667181b63d44f1e852dc132ca2326dabfd03c
+oid sha256:f6f326aabce20ec26afdb703e0fd610fe7f6c2f69c752e13fc1a1880d9c79e88
 size 107674

--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.0-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.0-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c0e0a425f49bd4b5a457d6cc4f667181b63d44f1e852dc132ca2326dabfd03c
+size 107674

--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.1-0.rc1.1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.1-0.rc1.1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d85349e2a8713f84adf73051bc574608bd58fbf61c47cb4e40902f56aa274f19
+size 104870

--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.1-0.rc1.1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.3.1-0.rc1.1.fc25.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d85349e2a8713f84adf73051bc574608bd58fbf61c47cb4e40902f56aa274f19
+oid sha256:63c19d3d2a320e34c01ad69c288bb57ba0edfb4e755b05423270227cfb27a769
 size 104870


### PR DESCRIPTION
###
Name of package: `securedrop-workstation-dom0-config`

There are two versions of the package in here:

 * 0.3.0 - current stable, not yet backported to test repo, so doing so here
 * 0.3.1-rc1 - pending QA for release, see https://github.com/freedomofpress/securedrop-workstation/issues/571


### Test plan
Confirm the following for the `0.3.1-rc1` package:

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.3.1-rc1
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/b93a2ce552b3729d729610782d1068ff34b6c63e
- [ ] CI is passing, the rpm is properly signed with the test key
- [ ] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs

For the `0.3.0` stable package, confirm the following:

- [ ] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs: https://github.com/freedomofpress/build-logs/blob/b93a2ce552b3729d729610782d1068ff34b6c63e/workstation/securedrop-workstation-dom0-config-0.3.0

