### PR TITLE
rpm for securedrop-workstation-dom0-config-0.4.0-rc1

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.4.0-0.rc1.1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.4.0-0.rc1.1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58f7576757a5eba5192c674dce74d218b233a7410c8e8c0af8ff7f088d8b4bc9
+size 104530


### PR DESCRIPTION
###
Name of package: `securedrop-workstation-dom0-config-0.4.0-rc1`

### Test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.4.0-rc1
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/blob/master/workstation/securedrop-workstation-dom0-config-0.4.0-rc1
- [ ] CI is passing, the rpm is properly signed with the test key
- [ ] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs
