### PR TITLE
Adds sdw-dom0-config 0.5.0-rc2

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.0-0.rc2.1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.0-0.rc2.1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1bebfad79ed2756c53bad36168cba451318605358c9546b3e698747b02d11ef2
+size 107790


### PR DESCRIPTION
###
Name of package: `securedrop-workstation-dom0-config`


### Test plan
According to the wiki docs (https://github.com/freedomofpress/securedrop-workstation/wiki/Building-securedrop-workstation-dom0-config-RPM-package), I should have tagged on the PR prior merge (https://github.com/freedomofpress/securedrop-workstation/pull/626). Instead, I tagged on main. 

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.5.0-rc2
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/ae58d47039cd11e222ffab16130e16327b14dfb2
- [x] CI is passing, the rpm is properly signed with the test key
- [x] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs
