### PR TITLE
Adds sdw-dom0-config 0.5.0-rc3

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.0-0.rc3.1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.0-0.rc3.1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d362719fb42e8bc0f0f89397f487118b25b87b26edd5cc248f75f11cc0ea7cb
+size 107902


### PR DESCRIPTION
###
Name of package: `securedrop-workstation-dom0-config`


### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.5.0-rc3
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/165d3e7bf3b360ac69d9f780986472b752a331e8
- [x] CI is passing, the rpm is properly signed with the test key
- [x] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs
