### PR TITLE
Adds sdw-dom0-config 0.5.1-rc1

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.1-0.rc1.1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.1-0.rc1.1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe5a6e1f805f6c08e1bffc6700c9f5b7dbb09cec3b66887e3f6a9e936d923984
+size 107858


### PR DESCRIPTION
###
Name of package: `securedrop-workstation-dom0-config`


### Test plan

- [ ] Tag in securedrop-workstation repository is correct:https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.5.1-rc1
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/f74081e23edef196a10213c25cd95b3aacee9dc1
- [ ] CI is passing, the rpm is properly signed with the test key
- [ ] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs
