### PR TITLE
Adds sdw-dom0-config 0.5.2

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.2-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.2-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0458a03e91a270a76fadac3e4e66698f41880471f5c73690e63d38f9a9985d7
+size 108050


### PR DESCRIPTION

###
Name of package: `securedrop-workstation-dom0-config`

Using the same RPM build for prod, but signed here with the test key. See corresponding prod package at https://github.com/freedomofpress/securedrop-workstation-prod-rpm-packages-lfs/pull/15

### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.5.2
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/7b94b07705c7e584165b78ea989da253734c6e8d
- [x] CI is passing, the rpm is properly signed with the test key
- [x] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs
