### PR TITLE
Adds sdw-dom0-config 0.5.4-rc1

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.4-0.rc1.1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.4-0.rc1.1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffa4f1241dcc3f48ece4f26034589a48f39d15433ea4d289a3db48bb4292065c
+size 122963


### PR DESCRIPTION
### Overview
Name of package: `securedrop-workstation-dom0-config`

This package is signed with the new 2021 prod release signing key,
2359E6538C0613E652955E6C188EDD3B7B22E6A3, rather than the typical
test repo key. That's intentional, to aid in testing for pre-release QA
for SDW 0.5.4 final.

### Test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.5.4-rc1
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/48116af332691f7324482ef25ea19e8afb90e21e
- [ ] ~~CI is passing, the rpm is properly signed with the test key~~ CI will fail, that's OK!
- [ ] RPM is signed with new release signing key
- [ ] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs
