### PR TITLE
Resigns sdw-dom0-config 0.5.4-rc1 with test key

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.4-0.rc1.1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.4-0.rc1.1.fc25.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ffa4f1241dcc3f48ece4f26034589a48f39d15433ea4d289a3db48bb4292065c
+oid sha256:f3e5c26826f3e66d78aee94a552145369389ba40ecb4b5ef654fd3757b98218b
 size 122963


### PR DESCRIPTION


### Overview
Follow-up to https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/pull/24

We've performed the manual testing as part of [0], so let's
remove the non-standard signature and overwrite it with
a sig from the standard test key, i.e. 4ED79CC3362D7D12837046024A3BE4A92211B03C.

[0] https://github.com/freedomofpress/securedrop-workstation/pull/700
### Test plan

- [ ] CI is passing
- [ ] Run `rpm --delsign <rpm>` on this package, then do the same for the package in https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/pull/24. The checksums should match, since only the sigs are different.
