### PR TITLE
add workstation template 0.2.3

### DIFF
--- a/workstation/dom0/f25/qubes-template-securedrop-workstation-buster-4.0.6-202106042129.noarch.rpm
+++ b/workstation/dom0/f25/qubes-template-securedrop-workstation-buster-4.0.6-202106042129.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:685b3d17e15039533a88a534d5ba2e7326a9a3de3bbb40135c672a74767bd8e1
+size 861302773


### PR DESCRIPTION
###
Name of package: `qubes-template-securedrop-workstation`

Towards https://github.com/freedomofpress/qubes-template-securedrop-workstation/issues/20

### Test plan
- [ ] Tag in qubes-template-securedrop-workstation repository is correct: https://github.com/freedomofpress/qubes-template-securedrop-workstation/releases/tag/0.2.3
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/2b2738fbcb761c7551a5eec7052e984fd764ce4b
- [ ] CI is passing, the rpm is properly signed with the test key
- [ ] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs

### VM sanity check
I have not yet performed these simple tests to verify VM functionality, please do so as part of review:

- [ ] Template installs successfully in dom0
- [ ] Set VM to HVM and kernel to `''`
- [ ] Template boots in grsecurity kernel
- [ ] apt-key finger shows the release key in its own keyring
- [ ] the old key is not present
- [ ] securedrop-keyring package is installed
- [ ] `sudo echo hello` does not prompt for sudo password

See https://github.com/freedomofpress/qubes-template-securedrop-workstation/pull/20 for reference


