### PR TITLE
Adds sdw-config 0.5.5

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.5-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.5-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6789a53791169bb8d229862ec16b1cd715f861fcb983949f0c652a7d1a805a79
+size 123235


### PR DESCRIPTION


###
Name of package: `securedrop-workstation-dom0-config`

Signed with test key, for inclusion in yum-test.
### Test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.5.5
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/da7964dc621dd8abadf4e0084c329c38d7b96438
- [ ] CI is passing, the rpm is properly signed with the test key
- [ ] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs
