### PR TITLE
Add sdw-dom0-config 0.5.7 RPM

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.7-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.7-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:794ba7079178aac9140ede138a6a473df769a3fb65536d052bac0eed79acf00f
+size 123109


### PR DESCRIPTION
###
Name of package: `securedrop-workstation-dom0-config`

Towards https://github.com/freedomofpress/securedrop-workstation/issues/737


### Test plan

Run through the usual verification steps:

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.5.7
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/5b9ec0d1cac962b0de06d069410cf3ff72a9c5c0
- [ ] CI is passing, the rpm is properly signed with the test key
- [ ] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs

## Deployment plan

While I believe these changes are final, and shipping them to prod isn't worth shipping to staging first and re-verifying the testing performed in both https://github.com/freedomofpress/securedrop-workstation/issues/735#issuecomment-963404438 and https://github.com/freedomofpress/securedrop-workstation/pull/736#pullrequestreview-806644206, I do see value in testing a clean install of this package via yum-test in order to validate some recent server-side changes for the yum repo logic. 
