### PR TITLE
Use debian:buster CircleCI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,13 @@ version: 2.1
 jobs:
   tests:
     docker:
-      - image: circleci/python:3.7-buster
+      - image: debian:buster
     steps:
+      - run: apt-get update && apt-get install -y sudo
       - run:
           name: Install Debian packaging dependencies
           command: |
-            sudo apt install rpm git-lfs
+            sudo apt install -y python3 git rpm git-lfs
 
       - run:
           name: Clone the repository with LFS


### PR DESCRIPTION
Unbreak [CI issue](https://app.circleci.com/pipelines/github/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/176/workflows/8bc2c20b-b83e-4caa-8802-b6cdea6c3f41/jobs/181) as seen in https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/pull/30 (current circleci image is deprecated)

## Test Plan
- [ ] CI passes
- [ ] Visual review seems sensible