### PR TITLE
add securedrop-workstation-dom0-config 0.6.1-rc1

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.1-0.rc1.1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.1-0.rc1.1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37ea0b7cbad4e9e693c0bf6d78b0951f58d888a1f24949b7b4e4ab4770a5c878
+size 127785


### PR DESCRIPTION
###
Name of package: `securedrop-workstation-dom0-config`, version `0.6.1-rc1`

### Test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.6.1-rc1
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/c4be120650cdbaef545ba72dbe67e2b6713b6fd8
- [ ] CI is passing (therefore we know the rpm is properly signed with the test key)
- [ ] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs
