### PR TITLE
Release qubes-template-securedrop-workstation for Qubes 4.1

### DIFF
--- a/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.0.6-202206132300.noarch.rpm
+++ b/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.0.6-202206132300.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d94a4f1e2afc51a220ae8ac5a08a97ba4698efb4badcfb0182d0c061368eee9e
+size 897266789


### PR DESCRIPTION
Note that I am using a similar PR structure as we are aiming to introduce in the prod lfs repo (see https://github.com/freedomofpress/securedrop-workstation-prod-rpm-packages-lfs/pull/31)

## Description

Package being released: `qubes-template-securedrop-workstation`
Package tag: https://github.com/freedomofpress/qubes-template-securedrop-workstation/releases/tag/0.3.0-rc1
Build logs: https://github.com/freedomofpress/build-logs/commit/69b52ce2f53d719e9240102fbc9e14c0a49dce84 and https://github.com/freedomofpress/build-logs/commit/1920bd4e6d8ed2e09cf6d97a6fa00dd904f4d58d
Test signing key used to sign package and tag: https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/blob/HEAD/pubkeys/test.key

Release tracking issue: https://github.com/freedomofpress/securedrop-workstation-prod-rpm-packages-lfs/issues/33

## Checklist for PR owner

- [x] Links in this PR template have been updated as required
- [x] https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/blob/HEAD/pubkeys/test.key points to the correct test signing key

## Checklist for reviewer
- [x] CI is passing
- [x] The commits being released are what you expect (see https://github.com/freedomofpress/qubes-template-securedrop-workstation/compare/0.2.3...0.3.0-rc1)
- [x] The RPM is signed with the test signing key
    > * Download the signed RPM from this PR
    > * Run `rpm -qi <signed-rpm>` to get the KEY ID
    > * Run `gpg -k <KEY ID>` to verify that it matches the test signing key (make sure you have the test signing key referenced in the PR description in your GPG keyring)
- [x] The Unsigned RPM checksum matches what's in the build logs (see https://github.com/freedomofpress/build-logs/commit/1920bd4e6d8ed2e09cf6d97a6fa00dd904f4d58d)
    > * Download the signed RPM from this PR (if you haven't already)
    > * Run `rpm --delsign <signed-rpm>` to remove the signature
    > * Run `sha256sum <unsigned-rpm>` and compare
