### PR TITLE
add securedrop-workstation-dom0-config 0.6.3 signed package

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.3-1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.6.3-1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7e4314e644579c34af3279c2187569a3d1f49856ef3ec9abc96321620e541b4
+size 126046


### PR DESCRIPTION
## Description

Package being released: `securedrop-workstation-dom0-config 0.6.3`
Package tag: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.6.3
Build logs: https://github.com/freedomofpress/build-logs/blob/main/workstation/securedrop-workstation-dom0-config-0.6.3
Test signing key used to sign package and tag: https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/blob/HEAD/pubkeys/test.key

Release tracking issue: https://github.com/freedomofpress/securedrop-workstation-prod-rpm-packages-lfs/issues/33

## Checklist for PR owner

- [x] Links in this PR template have been updated as required
- [x] https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/blob/HEAD/pubkeys/test.key points to the correct test signing key

## Checklist for reviewer
- [x] CI is passing
- [x] The commits being released are what you expect (see https://github.com/freedomofpress/securedrop-workstation/compare/0.6.2...0.6.3)
- [x] The RPM is signed with the test signing key
    > * Download the signed RPM from this PR
    > * Run `rpm -qi <signed-rpm>` to get the KEY ID
    > * Run `gpg -k <KEY ID>` to verify that it matches the test signing key (make sure you have the test signing key referenced in the PR description in your GPG keyring)
- [x] The Unsigned RPM checksum matches what's in the build logs
    > * Download the signed RPM from this PR (if you haven't already)
    > * Run `rpm --delsign <signed-rpm>` to remove the signature (do this on same OS used to build the package, in this case it's Debian)
    > * Run `sha256sum <unsigned-rpm>` and compare
