### PR TITLE
Release qubes-template-securedrop-workstation (build tag: 0.3.0)

### DIFF
--- a/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.0.6-202206302135.noarch.rpm
+++ b/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.0.6-202206302135.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43e4cdc74963014df0d5c82dcfff0311fa7e0d21c7c9b3981e7517482211359c
+size 894940033

--- a/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.0.6-202206302135.noarch.rpm
+++ b/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.0.6-202206302135.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:43e4cdc74963014df0d5c82dcfff0311fa7e0d21c7c9b3981e7517482211359c
+oid sha256:193150c1fa2902522b2689e4f0d7f615c232caf666c9bafccaa28c7faf4e811e
 size 894940033


### PR DESCRIPTION
Note that I am using a similar PR structure as we are aiming to introduce in the prod lfs repo (see https://github.com/freedomofpress/securedrop-workstation-prod-rpm-packages-lfs/pull/31)

## Description

Package being released: `qubes-template-securedrop-workstation`
Package tag: https://github.com/freedomofpress/qubes-template-securedrop-workstation/releases/tag/0.3.0
Build logs: https://github.com/freedomofpress/build-logs/commit/cd137103c2af006692e7e65561473a49c706139e (note that I had to rebuild the template so it's easier to look at the files without the diff view: https://github.com/freedomofpress/build-logs/blob/cd137103c2af006692e7e65561473a49c706139e/workstation/qubes-template-securedrop-workstation-bullseye-4.0.6-202206302135/)
Test signing key used to sign package and tag: https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/blob/HEAD/pubkeys/test.key

Release tracking issue: https://github.com/freedomofpress/securedrop-workstation-prod-rpm-packages-lfs/issues/33

## Checklist for PR owner

- [x] Links in this PR template have been updated as required
- [x] https://github.com/freedomofpress/securedrop-workstation-dev-rpm-packages-lfs/blob/HEAD/pubkeys/test.key points to the correct test signing key

## Checklist for reviewer
- [ ] CI is passing
- [ ] The commits being released are what you expect (see https://github.com/freedomofpress/qubes-template-securedrop-workstation/compare/0.2.3...0.3.0-rc1)
- [ ] The RPM is signed with the test signing key
    > * Download the signed RPM from this PR
    > * Run `rpm -qi <signed-rpm>` to get the KEY ID
    > * Run `gpg -k <KEY ID>` to verify that it matches the test signing key (make sure you have the test signing key referenced in the PR description in your GPG keyring)
- [ ] The Unsigned RPM checksum matches what's in the build logs (see https://github.com/freedomofpress/build-logs/blob/cd137103c2af006692e7e65561473a49c706139e/workstation/qubes-template-securedrop-workstation-bullseye-4.0.6-202206302135/Makefile.out)
    > * Download the signed RPM from this PR (if you haven't already)
    > * Run `rpm --delsign <signed-rpm>` to remove the signature (do this on fedora 33 or 34, see last line in build logs for rpm version)
    > * Run `sha256sum <unsigned-rpm>` and compare

## QA

Follow QA test plan in tracking issue