### PR TITLE
Add securedrop-workstation-dom0-config-0.7.1

### DIFF
--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.7.1-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.7.1-1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96f404e05940e3cb44e1074264195d5c85d29cc3fa4fac73f0121c55e00f4d01
+size 117456

--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.7.1-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.7.1-1.fc32.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:96f404e05940e3cb44e1074264195d5c85d29cc3fa4fac73f0121c55e00f4d01
+oid sha256:52dad009618bfb362e02baf8d8ddd098646a463c8b5cf4d9b58b251ef8313edf
 size 117456


### PR DESCRIPTION
### Description

Name of package: securedrop-workstation-dom0-config-0.7.1

### Test plan

- [ ] Confirm that not verifying the tag signature is OK. ~Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/x.y.z~
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/pull/10
- [ ] CI is passing, the rpm is properly signed with the test key
- [ ] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs
